### PR TITLE
🐛🚚: rename namespace font icons

### DIFF
--- a/src/views/fonts.rs
+++ b/src/views/fonts.rs
@@ -4,6 +4,6 @@ use iced::Font;
 
 /// Icon's font to be used in the app
 pub const FONT_ICONS: Font = Font::External {
-    name: "Icons",
+    name: "BasicIcons",
     bytes: include_bytes!("../../assets/fonts/icons.ttf"),
 };


### PR DESCRIPTION
[iced_aw](https://github.com/iced-rs/iced_aw) has a known issue: 

> https://github.com/iced-rs/iced_aw/issues/34

about the name space of the icons used by `iced_aw` so the icons used by date picker were not display correctly

So i need to rename the namespace of my own icons